### PR TITLE
Update to latest stable version of provider

### DIFF
--- a/flutter_searchbox/pubspec.yaml
+++ b/flutter_searchbox/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_searchbox
 description: Flutter Searchbox provides declarative API to query Elasticsearch, and binds UI widgets with different types of search queries. As the name suggests, it provides a searchbox UI widget for Elasticsearch and Appbase.io.
-version: 2.2.0-nullsafety
+version: 2.2.1-nullsafety
 homepage: https://github.com/appbaseio/flutter-searchbox
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
   flutter_feather_icons: ^2.0.0+1
   searchbase: ^2.2.0
   speech_to_text: ^4.1.1-nullsafety
-  provider: ^5.0.0
+  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
At funda we use other flutter modules which use the latest version of bloc_provider that uses provider 6.0.0. To be able to package all the modules, it is necessary that all libraries use the latest and greatest stable version of provider.