### PR TITLE
fix: selectedfilters component allows only List/ Map values

### DIFF
--- a/flutter_searchbox_ui/lib/src/components/selected_filters.dart
+++ b/flutter_searchbox_ui/lib/src/components/selected_filters.dart
@@ -243,7 +243,7 @@ class _SelectedFiltersState extends State<SelectedFilters> {
   void setSelectedFilters() {
     try {
       final activeWidgets = this.activeWidgets;
-
+      print('activewidgets $activeWidgets');
       for (var id in activeWidgets.keys) {
         if (widget.subscribeTo != null && widget.subscribeTo!.isNotEmpty) {
           if (!widget.subscribeTo!.contains(id)) {
@@ -256,11 +256,7 @@ class _SelectedFiltersState extends State<SelectedFilters> {
         if (mounted) {
           setState(() {
             final currentValue = componentInstance!.value;
-            if (currentValue != "" &&
-                currentValue != null &&
-                ((currentValue is Map || currentValue is List)
-                    ? currentValue.isNotEmpty
-                    : false) &&
+            if (!isNullEmptyOrFalse(currentValue) &&
                 (widget.hideDefaultValues == true
                     ? !isEqual(currentValue, widget.defaultValues![id])
                     : true)) {
@@ -274,11 +270,7 @@ class _SelectedFiltersState extends State<SelectedFilters> {
         componentInstance?.subscribeToStateChanges((changes) {
           void applyChanges() {
             final currentValue = changes['value']?.next;
-            if (currentValue != "" &&
-                currentValue != null &&
-                ((currentValue is Map || currentValue is List)
-                    ? currentValue.isNotEmpty
-                    : false) &&
+            if (!isNullEmptyOrFalse(currentValue) &&
                 (widget.hideDefaultValues == true
                     ? !isEqual(currentValue, widget.defaultValues![id])
                     : true)) {

--- a/flutter_searchbox_ui/lib/src/components/selected_filters.dart
+++ b/flutter_searchbox_ui/lib/src/components/selected_filters.dart
@@ -243,7 +243,6 @@ class _SelectedFiltersState extends State<SelectedFilters> {
   void setSelectedFilters() {
     try {
       final activeWidgets = this.activeWidgets;
-      print('activewidgets $activeWidgets');
       for (var id in activeWidgets.keys) {
         if (widget.subscribeTo != null && widget.subscribeTo!.isNotEmpty) {
           if (!widget.subscribeTo!.contains(id)) {

--- a/flutter_searchbox_ui/lib/src/utils.dart
+++ b/flutter_searchbox_ui/lib/src/utils.dart
@@ -83,7 +83,7 @@ List prepareValueList(Map value) {
 }
 
 String processFilterValues(dynamic value) {
-  if (value == null || value.isEmpty) {
+  if (isNullEmptyOrFalse(value)) {
     return "";
   }
   if (value is String) {
@@ -128,5 +128,5 @@ bool isNullEmptyOrFalse(dynamic val) {
   if (val is Map || val is List) {
     return !val.isNotEmpty;
   }
-  return val == null || false == val || "" == val;
+  return val == null || val == "";
 }

--- a/flutter_searchbox_ui/lib/src/utils.dart
+++ b/flutter_searchbox_ui/lib/src/utils.dart
@@ -123,3 +123,10 @@ bool isEqual(dynamic value, dynamic defaultValue) {
     return false;
   }
 }
+
+bool isNullEmptyOrFalse(dynamic val) {
+  if (val is Map || val is List) {
+    return !val.isNotEmpty;
+  }
+  return val == null || false == val || "" == val;
+}

--- a/flutter_searchbox_ui/lib/src/utils.dart
+++ b/flutter_searchbox_ui/lib/src/utils.dart
@@ -128,5 +128,5 @@ bool isNullEmptyOrFalse(dynamic val) {
   if (val is Map || val is List) {
     return !val.isNotEmpty;
   }
-  return val == null || false == val || "" == val;
+  return val == null || val == "";
 }


### PR DESCRIPTION
**PR Type** 🐞 `Fix`

**Description** 
- [x]  `SelectedFilters` component
    - [x]  It doesn’t display the `string` type of values. Use it with `SearchBox` component and select a query. `SelectedFilters` only shows the `List` and `Map` values.
    
    ⇒ The ideal behavior is to provide filter values irrespective of the value type.

[📔 Notion](https://www.notion.so/appbase/Funda-Issues-bc9b05c3275b41eab77b7294ddb45781)

**Demo(s)**
- https://www.loom.com/share/1f40c10d7c10447dab3b2cc6939a4028
- https://www.loom.com/share/480ef52fcbc64edfaa6b38ab2dcfde80
