### PR TITLE
feat: compoundClause property

### DIFF
--- a/flutter_searchbox/CHANGELOG.md
+++ b/flutter_searchbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.10-beta
+
+- Upgrade searchbase
+
 ## 3.2.9-beta
 
 - add support for `compoundClause` property

--- a/flutter_searchbox/CHANGELOG.md
+++ b/flutter_searchbox/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.2.8-beta
+## 3.2.9-beta
 
-- upgrade searchbase
+- add support for `compoundClause` property
 
 ## 3.2.7-beta
 

--- a/flutter_searchbox/example/pubspec.lock
+++ b/flutter_searchbox/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.1-beta"
+    version: "3.2.8-beta"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -203,10 +203,10 @@ packages:
     dependency: "direct main"
     description:
       name: searchbase
-      sha256: "4ff3b573cc9ba96543cb2ff4048f17c7a8ac716b8f37467964f025a31eec8da5"
+      sha256: "0d7edf295d31cfdedae5a7561622585e0d2e75ec332bc2f82757ee52a3425521"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0-beta"
+    version: "3.4.10-beta"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/flutter_searchbox/example/pubspec.lock
+++ b/flutter_searchbox/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.8-beta"
+    version: "3.2.9-beta"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -203,10 +203,10 @@ packages:
     dependency: "direct main"
     description:
       name: searchbase
-      sha256: "0d7edf295d31cfdedae5a7561622585e0d2e75ec332bc2f82757ee52a3425521"
+      sha256: f5e24057061003b50c7a8c24bf421e8fbb873623ef82b8c3ce4d01ca55bd9b06
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.10-beta"
+    version: "3.4.11-beta"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/flutter_searchbox/lib/src/components/searchbox.dart
+++ b/flutter_searchbox/lib/src/components/searchbox.dart
@@ -791,6 +791,22 @@ class SearchBox<S, ViewModel> extends SearchDelegate<String?> {
   /// ```
   final Map? distinctFieldConfig;
 
+  /// Configure whether the DSL query is generated with the compound clause of [CompoundClauseType.must] or [CompoundClauseType.filter]. If nothing is passed the default is to use [CompoundClauseType.must].
+  /// Setting the compound clause to filter allows search engine to cache and allows for higher throughput in cases where scoring isn’t relevant (e.g. term, geo or range type of queries that act as filters on the data)
+  ///
+  /// This property only has an effect when the search engine is either elasticsearch or opensearch.
+  /// > Note: `compoundClause` is supported with v8.16.0 (server) as well as with serverless search.
+  ///
+  ///   ///
+  /// For example,
+  /// ```dart
+  /// SearchBox(
+  ///   ...
+  ///   compoundClause:  CompoundClauseType.filter
+  /// )
+  /// ```
+  CompoundClauseType? compoundClause;
+
   /* ---- callbacks to create the side effects while querying ----- */
 
   /// It is a callback function which accepts component's future **value** as a
@@ -887,71 +903,73 @@ class SearchBox<S, ViewModel> extends SearchDelegate<String?> {
   /// - a search icon to perform search action etc.
   List<Widget>? customActions;
 
-  SearchBox(
-      {Key? key,
-      required this.id,
-      // properties to configure search component
-      this.credentials,
-      this.index,
-      this.url,
-      this.appbaseConfig,
-      this.transformRequest,
-      this.transformResponse,
-      this.headers,
-      this.react,
-      this.queryFormat,
-      this.dataField,
-      this.categoryField,
-      this.categoryValue,
-      this.nestedField,
-      this.from,
-      this.size,
-      this.sortBy,
-      this.aggregationField,
-      this.aggregationSize,
-      this.after,
-      this.includeNullValues,
-      this.includeFields,
-      this.excludeFields,
-      this.fuzziness,
-      this.searchOperators,
-      this.highlight,
-      this.highlightField,
-      this.customHighlight,
-      this.interval,
-      this.aggregations,
-      this.missingLabel,
-      this.showMissing,
-      this.enableSynonyms,
-      this.selectAllLabel,
-      this.pagination,
-      this.queryString,
-      this.defaultQuery,
-      this.customQuery,
-      this.beforeValueChange,
-      this.onValueChange,
-      this.onResults,
-      this.onAggregationData,
-      this.onError,
-      this.onRequestStatusChange,
-      this.onQueryChange,
-      this.enablePopularSuggestions,
-      this.maxPopularSuggestions,
-      this.showDistinctSuggestions = true,
-      this.preserveResults,
-      this.clearOnQueryChange = true,
-      this.distinctField,
-      this.distinctFieldConfig,
-      // searchbox specific properties
-      this.enableRecentSearches = false,
-      this.showAutoFill = false,
-      // to customize ui
-      this.buildSuggestionItem,
-      // voice search
-      this.speechToTextInstance,
-      this.micOptions,
-      // custom actions
-      this.customActions});
+  SearchBox({
+    Key? key,
+    required this.id,
+    // properties to configure search component
+    this.credentials,
+    this.index,
+    this.url,
+    this.appbaseConfig,
+    this.transformRequest,
+    this.transformResponse,
+    this.headers,
+    this.react,
+    this.queryFormat,
+    this.dataField,
+    this.categoryField,
+    this.categoryValue,
+    this.nestedField,
+    this.from,
+    this.size,
+    this.sortBy,
+    this.aggregationField,
+    this.aggregationSize,
+    this.after,
+    this.includeNullValues,
+    this.includeFields,
+    this.excludeFields,
+    this.fuzziness,
+    this.searchOperators,
+    this.highlight,
+    this.highlightField,
+    this.customHighlight,
+    this.interval,
+    this.aggregations,
+    this.missingLabel,
+    this.showMissing,
+    this.enableSynonyms,
+    this.selectAllLabel,
+    this.pagination,
+    this.queryString,
+    this.defaultQuery,
+    this.customQuery,
+    this.beforeValueChange,
+    this.onValueChange,
+    this.onResults,
+    this.onAggregationData,
+    this.onError,
+    this.onRequestStatusChange,
+    this.onQueryChange,
+    this.enablePopularSuggestions,
+    this.maxPopularSuggestions,
+    this.showDistinctSuggestions = true,
+    this.preserveResults,
+    this.clearOnQueryChange = true,
+    this.distinctField,
+    this.distinctFieldConfig,
+    // searchbox specific properties
+    this.enableRecentSearches = false,
+    this.showAutoFill = false,
+    // to customize ui
+    this.buildSuggestionItem,
+    // voice search
+    this.speechToTextInstance,
+    this.micOptions,
+    // custom actions
+    this.customActions,
+    this.compoundClause,
+  });
 
   @override
   List<Widget> buildActions(BuildContext context) {
@@ -1151,6 +1169,7 @@ class SearchBox<S, ViewModel> extends SearchDelegate<String?> {
         value: query,
         distinctField: distinctField,
         distinctFieldConfig: distinctFieldConfig,
+        compoundClause: compoundClause,
         builder: (context, searchController) {
           if (query != searchController.value) {
             // To fetch the suggestions

--- a/flutter_searchbox/lib/src/components/searchwidgetconnector.dart
+++ b/flutter_searchbox/lib/src/components/searchwidgetconnector.dart
@@ -224,6 +224,22 @@ class _SearchWidgetListener<S, ViewModel> extends StatefulWidget {
   /// Defaults to 30 seconds.
   Duration httpRequestTimeout;
 
+  /// Configure whether the DSL query is generated with the compound clause of [CompoundClauseType.must] or [CompoundClauseType.filter]. If nothing is passed the default is to use [CompoundClauseType.must].
+  /// Setting the compound clause to filter allows search engine to cache and allows for higher throughput in cases where scoring isn’t relevant (e.g. term, geo or range type of queries that act as filters on the data)
+  ///
+  /// This property only has an effect when the search engine is either elasticsearch or opensearch.
+  /// > Note: `compoundClause` is supported with v8.16.0 (server) as well as with serverless search.
+  ///
+  ///   ///
+  /// For example,
+  /// ```dart
+  /// SearchBox(
+  ///   ...
+  ///   compoundClause:  CompoundClauseType.filter
+  /// )
+  /// ```
+  CompoundClauseType? compoundClause;
+
   /* ---- callbacks to create the side effects while querying ----- */
 
   final Future Function(dynamic value)? beforeValueChange;
@@ -313,6 +329,7 @@ class _SearchWidgetListener<S, ViewModel> extends StatefulWidget {
     this.distinctField,
     this.distinctFieldConfig,
     this.httpRequestTimeout = const Duration(seconds: 30),
+    this.compoundClause,
   }) : super(key: key) {}
   @override
   _SearchWidgetListenerState createState() =>
@@ -375,6 +392,7 @@ class _SearchWidgetListener<S, ViewModel> extends StatefulWidget {
           'distinctField': distinctField,
           'distinctFieldConfig': distinctFieldConfig,
           'httpRequestTimeout': httpRequestTimeout,
+          'compoundClause': compoundClause
         },
         builder: builder,
         subscribeTo: subscribeTo,
@@ -819,6 +837,22 @@ class SearchWidgetConnector<S, ViewModel> extends StatelessWidget {
   /// Defaults to 30 seconds.
   Duration httpRequestTimeout;
 
+  /// Configure whether the DSL query is generated with the compound clause of [CompoundClauseType.must] or [CompoundClauseType.filter]. If nothing is passed the default is to use [CompoundClauseType.must].
+  /// Setting the compound clause to filter allows search engine to cache and allows for higher throughput in cases where scoring isn’t relevant (e.g. term, geo or range type of queries that act as filters on the data)
+  ///
+  /// This property only has an effect when the search engine is either elasticsearch or opensearch.
+  /// > Note: `compoundClause` is supported with v8.16.0 (server) as well as with serverless search.
+  ///
+  ///   ///
+  /// For example,
+  /// ```dart
+  /// SearchBox(
+  ///   ...
+  ///   compoundClause:  CompoundClauseType.filter
+  /// )
+  /// ```
+  CompoundClauseType? compoundClause;
+
   /* ---- callbacks to create the side effects while querying ----- */
 
   /// It is a callback function which accepts component's future **value** as a
@@ -930,6 +964,7 @@ class SearchWidgetConnector<S, ViewModel> extends StatelessWidget {
     this.distinctField,
     this.distinctFieldConfig,
     this.httpRequestTimeout = const Duration(seconds: 30),
+    this.compoundClause,
   }) : super(key: key);
 
   @override
@@ -999,6 +1034,7 @@ class SearchWidgetConnector<S, ViewModel> extends StatelessWidget {
               distinctField: distinctField,
               distinctFieldConfig: distinctFieldConfig,
               httpRequestTimeout: httpRequestTimeout,
+              compoundClause: compoundClause,
             ));
   }
 }

--- a/flutter_searchbox/pubspec.lock
+++ b/flutter_searchbox/pubspec.lock
@@ -143,10 +143,10 @@ packages:
     dependency: "direct main"
     description:
       name: searchbase
-      sha256: f5e24057061003b50c7a8c24bf421e8fbb873623ef82b8c3ce4d01ca55bd9b06
+      sha256: f627f3baac4837959a172515237fcb7f9fe014345a9a08d7abdcaba69bcd5d3e
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.11-beta"
+    version: "3.4.12-beta"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/flutter_searchbox/pubspec.lock
+++ b/flutter_searchbox/pubspec.lock
@@ -143,10 +143,10 @@ packages:
     dependency: "direct main"
     description:
       name: searchbase
-      sha256: "0d7edf295d31cfdedae5a7561622585e0d2e75ec332bc2f82757ee52a3425521"
+      sha256: f5e24057061003b50c7a8c24bf421e8fbb873623ef82b8c3ce4d01ca55bd9b06
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.10-beta"
+    version: "3.4.11-beta"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/flutter_searchbox/pubspec.yaml
+++ b/flutter_searchbox/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_searchbox
 description: Flutter Searchbox provides declarative API to query Elasticsearch, and binds UI widgets with different types of search queries. As the name suggests, it provides a searchbox UI widget for Elasticsearch and Appbase.io.
-version: 3.2.8-beta
+version: 3.2.9-beta
 homepage: https://github.com/appbaseio/flutter-searchbox
 
 environment:

--- a/flutter_searchbox/pubspec.yaml
+++ b/flutter_searchbox/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_feather_icons: ^2.0.0+1
-  searchbase: ^3.4.10-beta
+  searchbase: ^3.4.11-beta
   provider: ^6.0.0
 
 dev_dependencies:

--- a/flutter_searchbox/pubspec.yaml
+++ b/flutter_searchbox/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_searchbox
 description: Flutter Searchbox provides declarative API to query Elasticsearch, and binds UI widgets with different types of search queries. As the name suggests, it provides a searchbox UI widget for Elasticsearch and Appbase.io.
-version: 3.2.9-beta
+version: 3.2.10-beta
 homepage: https://github.com/appbaseio/flutter-searchbox
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_feather_icons: ^2.0.0+1
-  searchbase: ^3.4.11-beta
+  searchbase: ^3.4.12-beta
   provider: ^6.0.0
 
 dev_dependencies:

--- a/flutter_searchbox_ui/CHANGELOG.md
+++ b/flutter_searchbox_ui/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.11-beta
+
+- Upgrade searchbase
+- Upgrade flutter_searchbox
+
 ## 3.2.10-beta
 
 - add support for `compoundClause` property

--- a/flutter_searchbox_ui/CHANGELOG.md
+++ b/flutter_searchbox_ui/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.10-beta
+
+- add support for `compoundClause` property
+
 ## 3.2.9-beta
 
 - RangeInput: triggerQueryOnMount prop support

--- a/flutter_searchbox_ui/example/pubspec.lock
+++ b/flutter_searchbox_ui/example/pubspec.lock
@@ -98,17 +98,17 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_searchbox
-      sha256: b97500ec4ffebe67d3364e66fbb808bb3c631a3b73417d64a914fb6bcd77692b
+      sha256: "3f71905faad13e1adc94761d6eefb280708182bc9bc7b10891d7ac760d9d5f17"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1-beta"
+    version: "3.2.9-beta"
   flutter_searchbox_ui:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "3.2.1-beta"
+    version: "3.2.10-beta"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -246,10 +246,10 @@ packages:
     dependency: "direct main"
     description:
       name: searchbase
-      sha256: "4ff3b573cc9ba96543cb2ff4048f17c7a8ac716b8f37467964f025a31eec8da5"
+      sha256: f5e24057061003b50c7a8c24bf421e8fbb873623ef82b8c3ce4d01ca55bd9b06
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0-beta"
+    version: "3.4.11-beta"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/flutter_searchbox_ui/lib/src/components/range_input.dart
+++ b/flutter_searchbox_ui/lib/src/components/range_input.dart
@@ -773,7 +773,7 @@ class RangeInput extends StatefulWidget {
   /// ```
   final Widget Function(bool showError)? dropdownIcon;
 
-  const RangeInput({
+  RangeInput({
     Key? key,
     required this.id,
     this.subscribeTo,

--- a/flutter_searchbox_ui/lib/src/components/range_input.dart
+++ b/flutter_searchbox_ui/lib/src/components/range_input.dart
@@ -453,6 +453,22 @@ class RangeInput extends StatefulWidget {
   /// Defaults to 30 seconds.
   final Duration httpRequestTimeout;
 
+  /// Configure whether the DSL query is generated with the compound clause of [CompoundClauseType.must] or [CompoundClauseType.filter]. If nothing is passed the default is to use [CompoundClauseType.must].
+  /// Setting the compound clause to filter allows search engine to cache and allows for higher throughput in cases where scoring isn’t relevant (e.g. term, geo or range type of queries that act as filters on the data)
+  ///
+  /// This property only has an effect when the search engine is either elasticsearch or opensearch.
+  /// > Note: `compoundClause` is supported with v8.16.0 (server) as well as with serverless search.
+  ///
+  ///   ///
+  /// For example,
+  /// ```dart
+  /// SearchBox(
+  ///   ...
+  ///   compoundClause:  CompoundClauseType.filter
+  /// )
+  /// ```
+  CompoundClauseType? compoundClause;
+
   /* ---- callbacks to create the side effects while querying ----- */
 
   /// It is a callback function which accepts component's future **value** as a
@@ -834,6 +850,7 @@ class RangeInput extends StatefulWidget {
     this.dropdownIcon,
     this.triggerQueryOnMount = true,
     this.httpRequestTimeout = const Duration(seconds: 30),
+    this.compoundClause,
   }) : super(key: key);
 
   @override
@@ -966,6 +983,7 @@ class _RangeInputState extends State<RangeInput> {
       onRequestStatusChange: widget.onRequestStatusChange,
       onQueryChange: widget.onQueryChange,
       httpRequestTimeout: widget.httpRequestTimeout,
+      compoundClause: widget.compoundClause,
     );
   }
 }

--- a/flutter_searchbox_ui/lib/src/components/reactive_google_map.dart
+++ b/flutter_searchbox_ui/lib/src/components/reactive_google_map.dart
@@ -618,6 +618,7 @@ class _ReactiveGoogleMapState extends State<ReactiveGoogleMap> {
       onRequestStatusChange: widget.onRequestStatusChange,
       onQueryChange: widget.onQueryChange,
       httpRequestTimeout: widget.httpRequestTimeout,
+      compoundClause: widget.compoundClause,
     );
   }
 }
@@ -1222,6 +1223,22 @@ class ReactiveGoogleMap extends StatefulWidget {
   /// ```
   final Map? distinctFieldConfig;
 
+  /// Configure whether the DSL query is generated with the compound clause of [CompoundClauseType.must] or [CompoundClauseType.filter]. If nothing is passed the default is to use [CompoundClauseType.must].
+  /// Setting the compound clause to filter allows search engine to cache and allows for higher throughput in cases where scoring isn’t relevant (e.g. term, geo or range type of queries that act as filters on the data)
+  ///
+  /// This property only has an effect when the search engine is either elasticsearch or opensearch.
+  /// > Note: `compoundClause` is supported with v8.16.0 (server) as well as with serverless search.
+  ///
+  ///   ///
+  /// For example,
+  /// ```dart
+  /// SearchBox(
+  ///   ...
+  ///   compoundClause:  CompoundClauseType.filter
+  /// )
+  /// ```
+  CompoundClauseType? compoundClause;
+
   /* ---- callbacks to create the side effects while querying ----- */
 
   /// It is a callback function which accepts component's future **value** as a
@@ -1607,6 +1624,7 @@ class ReactiveGoogleMap extends StatefulWidget {
     this.distinctField,
     this.distinctFieldConfig,
     this.httpRequestTimeout = const Duration(seconds: 30),
+    this.compoundClause,
 
     // Google map props
     required this.initialCameraPosition,

--- a/flutter_searchbox_ui/lib/src/components/reactive_google_map.dart
+++ b/flutter_searchbox_ui/lib/src/components/reactive_google_map.dart
@@ -1553,7 +1553,7 @@ class ReactiveGoogleMap extends StatefulWidget {
   /// Defaults to 30 seconds.
   final Duration httpRequestTimeout;
 
-  const ReactiveGoogleMap({
+  ReactiveGoogleMap({
     Key? key,
     required this.id,
     this.showMarkerClusters = true,

--- a/flutter_searchbox_ui/pubspec.lock
+++ b/flutter_searchbox_ui/pubspec.lock
@@ -90,10 +90,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_searchbox
-      sha256: "3f71905faad13e1adc94761d6eefb280708182bc9bc7b10891d7ac760d9d5f17"
+      sha256: "5e1d478929e0e1e9820317e5d036bfe923ac11ba7573cf0baf2d487623c57877"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.9-beta"
+    version: "3.2.10-beta"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -231,10 +231,10 @@ packages:
     dependency: "direct main"
     description:
       name: searchbase
-      sha256: f5e24057061003b50c7a8c24bf421e8fbb873623ef82b8c3ce4d01ca55bd9b06
+      sha256: f627f3baac4837959a172515237fcb7f9fe014345a9a08d7abdcaba69bcd5d3e
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.11-beta"
+    version: "3.4.12-beta"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/flutter_searchbox_ui/pubspec.lock
+++ b/flutter_searchbox_ui/pubspec.lock
@@ -90,10 +90,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_searchbox
-      sha256: "156a0ebfc6c20878924556a3406d2174755c49b81b14e6c6b97eb76c161be590"
+      sha256: "3f71905faad13e1adc94761d6eefb280708182bc9bc7b10891d7ac760d9d5f17"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.8-beta"
+    version: "3.2.9-beta"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -231,10 +231,10 @@ packages:
     dependency: "direct main"
     description:
       name: searchbase
-      sha256: "0d7edf295d31cfdedae5a7561622585e0d2e75ec332bc2f82757ee52a3425521"
+      sha256: f5e24057061003b50c7a8c24bf421e8fbb873623ef82b8c3ce4d01ca55bd9b06
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.10-beta"
+    version: "3.4.11-beta"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/flutter_searchbox_ui/pubspec.yaml
+++ b/flutter_searchbox_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_searchbox_ui
 description: Flutter Searchbox UI provides ui widgets to perform different type of search queries. As the name suggests, it provides UI widgets for Elasticseasrch.
-version: 3.2.9-beta
+version: 3.2.10-beta
 homepage: https://github.com/appbaseio/flutter-searchbox
 
 environment:
@@ -11,10 +11,10 @@ dependencies:
   dart_geohash: ^2.0.1
   flutter:
     sdk: flutter
-  flutter_searchbox: ^3.2.8-beta
+  flutter_searchbox: ^3.2.9-beta
   google_maps_cluster_manager: ^3.0.0+1
   google_maps_flutter: ^2.0.11
-  searchbase: ^3.4.10-beta
+  searchbase: ^3.4.11-beta
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/flutter_searchbox_ui/pubspec.yaml
+++ b/flutter_searchbox_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_searchbox_ui
 description: Flutter Searchbox UI provides ui widgets to perform different type of search queries. As the name suggests, it provides UI widgets for Elasticseasrch.
-version: 3.2.10-beta
+version: 3.2.11-beta
 homepage: https://github.com/appbaseio/flutter-searchbox
 
 environment:
@@ -11,10 +11,10 @@ dependencies:
   dart_geohash: ^2.0.1
   flutter:
     sdk: flutter
-  flutter_searchbox: ^3.2.9-beta
+  flutter_searchbox: ^3.2.10-beta
   google_maps_cluster_manager: ^3.0.0+1
   google_maps_flutter: ^2.0.11
-  searchbase: ^3.4.11-beta
+  searchbase: ^3.4.12-beta
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/searchbase/.dart_tool/package_config.json
+++ b/searchbase/.dart_tool/package_config.json
@@ -284,7 +284,7 @@
       "languageVersion": "2.12"
     }
   ],
-  "generated": "2023-07-18T05:40:41.785287Z",
+  "generated": "2023-08-05T14:57:10.578371Z",
   "generator": "pub",
   "generatorVersion": "2.19.6"
 }

--- a/searchbase/.dart_tool/package_config.json
+++ b/searchbase/.dart_tool/package_config.json
@@ -284,7 +284,7 @@
       "languageVersion": "2.12"
     }
   ],
-  "generated": "2023-08-05T14:57:10.578371Z",
+  "generated": "2023-08-07T15:16:39.792339Z",
   "generator": "pub",
   "generatorVersion": "2.19.6"
 }

--- a/searchbase/.dart_tool/package_config_subset
+++ b/searchbase/.dart_tool/package_config_subset
@@ -184,6 +184,6 @@ file:///Users/mohdashraf/.pub-cache/hosted/pub.dev/yaml-3.1.1/
 file:///Users/mohdashraf/.pub-cache/hosted/pub.dev/yaml-3.1.1/lib/
 searchbase
 2.12
-file:///Users/mohdashraf/Documents/Documents%20-%20Mohd%E2%80%99s%20MacBook%20Pro/GitHub/flutter-searchbox/searchbase/
-file:///Users/mohdashraf/Documents/Documents%20-%20Mohd%E2%80%99s%20MacBook%20Pro/GitHub/flutter-searchbox/searchbase/lib/
+file:///Users/mohdashraf/Documents/GitHub/flutter-searchbox/searchbase/
+file:///Users/mohdashraf/Documents/GitHub/flutter-searchbox/searchbase/lib/
 2

--- a/searchbase/CHANGELOG.md
+++ b/searchbase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.12-beta
+
+- add support to override widget config when re-registered through searchbase instance
+
 ## 3.4.11-beta
 
 - add support for `compoundClause` property

--- a/searchbase/CHANGELOG.md
+++ b/searchbase/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.11-beta
+
+- add support for `compoundClause` property
 ## 3.4.10-beta
 
 - fix: reset filters bug - regression

--- a/searchbase/lib/src/constants.dart
+++ b/searchbase/lib/src/constants.dart
@@ -62,3 +62,5 @@ extension SortTypeExtension on SortType? {
     }
   }
 }
+
+enum CompoundClauseType { filter, must }

--- a/searchbase/lib/src/searchbase.dart
+++ b/searchbase/lib/src/searchbase.dart
@@ -105,6 +105,12 @@ class SearchBase extends Base {
     }
     if (this._searchWidgets.containsKey(widgetId)) {
       // return existing instance
+
+      // If the widget is already registered and the componentConfig is a map, update the existing instance with the new configuration
+      if (searchController is Map) {
+        this._searchWidgets[widgetId]!.updateConfig(searchController);
+      }
+
       return this._searchWidgets[widgetId]!;
     }
     SearchController? componentInstance;
@@ -180,7 +186,7 @@ class SearchBase extends Base {
         distinctField: searchController["distinctField"],
         distinctFieldConfig: searchController["distinctFieldConfig"],
         httpRequestTimeout: searchController["httpRequestTimeout"],
-        compoundClause: searchController("compoundClause"),
+        compoundClause: searchController["compoundClause"],
       );
     } else if (searchController is SearchController) {
       componentInstance = searchController;

--- a/searchbase/lib/src/searchbase.dart
+++ b/searchbase/lib/src/searchbase.dart
@@ -180,6 +180,7 @@ class SearchBase extends Base {
         distinctField: searchController["distinctField"],
         distinctFieldConfig: searchController["distinctFieldConfig"],
         httpRequestTimeout: searchController["httpRequestTimeout"],
+        compoundClause: searchController("compoundClause"),
       );
     } else if (searchController is SearchController) {
       componentInstance = searchController;

--- a/searchbase/lib/src/searchcontroller.dart
+++ b/searchbase/lib/src/searchcontroller.dart
@@ -138,7 +138,7 @@ class SearchController extends Base {
   /// To set the number of buckets to be returned by aggregations.
   ///
   /// > Note: This is a new feature and only available for appbase versions >= 7.41.0.
-  final int? aggregationSize;
+  int? aggregationSize;
 
   /// This property can be used to implement the pagination for `aggregations`.
   ///
@@ -354,7 +354,7 @@ class SearchController extends Base {
   /// This prop returns only the distinct value documents for the specified field.
   /// It is equivalent to the DISTINCT clause in SQL. It internally uses the collapse feature of Elasticsearch.
   /// You can read more about it over here - https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
-  final String? distinctField;
+  String? distinctField;
 
   /// This prop allows specifying additional options to the distinctField prop.
   /// Using the allowed DSL, one can specify how to return K distinct values (default value of K=1),
@@ -378,7 +378,7 @@ class SearchController extends Base {
   ///   'max_concurrent_group_searches': 4, },
   /// )
   /// ```
-  final Map? distinctFieldConfig;
+  Map? distinctFieldConfig;
 
   /// This prop is used to set the timeout value for HTTP requests.
   /// Defaults to 30 seconds.
@@ -419,7 +419,7 @@ class SearchController extends Base {
   ///   // or Future.error()
   /// }
   /// ```
-  final Future Function(dynamic value)? beforeValueChange;
+  Future Function(dynamic value)? beforeValueChange;
 
   /* ------------- change events -------------------------------- */
 
@@ -427,26 +427,25 @@ class SearchController extends Base {
   ///
   /// This property is handy in cases where you want to generate a side-effect on value selection.
   /// For example: You want to show a pop-up modal with the valid discount coupon code when a user searches for a product in a [SearchController].
-  final void Function(dynamic next, {dynamic prev})? onValueChange;
+  void Function(dynamic next, {dynamic prev})? onValueChange;
 
   /// It can be used to listen for the `results` changes.
-  final void Function(Results next, {Results prev})? onResults;
+  void Function(Results next, {Results prev})? onResults;
 
   /// It can be used to listen for the `aggregationData` property changes.
-  final void Function(Aggregations next, {Aggregations prev})?
-      onAggregationData;
+  void Function(Aggregations next, {Aggregations prev})? onAggregationData;
 
   /// It gets triggered in case of an error while fetching results.
-  final void Function(dynamic error)? onError;
+  void Function(dynamic error)? onError;
 
   /// It can be used to listen for the request status changes.
-  final void Function(String? next, {String? prev})? onRequestStatusChange;
+  void Function(String? next, {String? prev})? onRequestStatusChange;
 
   /// It is a callback function which accepts widget's **nextQuery** and **prevQuery** as parameters.
   ///
   /// It is called everytime the widget's query changes.
   /// This property is handy in cases where you want to generate a side-effect whenever the widget's query would change.
-  final void Function(List<Map>? next, {List<Map>? prev})? onQueryChange;
+  void Function(List<Map>? next, {List<Map>? prev})? onQueryChange;
 
   /* ------ Private properties only for the internal use ----------- */
   SearchBase? _parent;
@@ -1188,6 +1187,100 @@ class SearchController extends Base {
         }
       ]
     };
+  }
+
+  void updateConfig(Map searchController) {
+    // Update the componentConfig with the provided values if they are not null
+    this.index = searchController["index"] ?? this.index;
+    this.url = searchController["url"] ?? this.url;
+    this.credentials = searchController["credentials"] ?? this.credentials;
+    this.headers =
+        searchController["headers"] as Map<String, String>? ?? this.headers;
+    this.transformRequest =
+        searchController["transformRequest"] as TransformRequest? ??
+            this.transformRequest;
+    this.transformResponse =
+        searchController["transformResponse"] as TransformResponse? ??
+            this.transformResponse;
+    this.appbaseConfig =
+        searchController["appbaseConfig"] as AppbaseSettings? ??
+            this.appbaseConfig;
+    this.type = searchController["type"] ?? this.type;
+    this.dataField = searchController["dataField"] ?? this.dataField;
+    this.react = searchController["react"] ?? this.react;
+    this.queryFormat = searchController["queryFormat"] ?? this.queryFormat;
+    this.categoryField =
+        searchController["categoryField"] ?? this.categoryField;
+    this.categoryValue =
+        searchController["categoryValue"] ?? this.categoryValue;
+    this.nestedField = searchController["nestedField"] ?? this.nestedField;
+    this.from = searchController["from"] ?? this.from;
+    this.size = searchController["size"] ?? this.size;
+    this.sortBy = searchController["sortBy"] ?? this.sortBy;
+    this.aggregationField =
+        searchController["aggregationField"] ?? this.aggregationField;
+    this.aggregationSize =
+        searchController["aggregationSize"] ?? this.aggregationSize;
+    this.after = searchController["after"] ?? this.after;
+    this.includeNullValues =
+        searchController["includeNullValues"] ?? this.includeNullValues;
+    this.includeFields =
+        searchController["includeFields"] ?? this.includeFields;
+    this.excludeFields =
+        searchController["excludeFields"] ?? this.excludeFields;
+    this.fuzziness = searchController["fuzziness"] ?? this.fuzziness;
+    this.searchOperators =
+        searchController["searchOperators"] ?? this.searchOperators;
+    this.highlight = searchController["highlight"] ?? this.highlight;
+    this.highlightField =
+        searchController["highlightField"] ?? this.highlightField;
+    this.customHighlight =
+        searchController["customHighlight"] ?? this.customHighlight;
+    this.interval = searchController["interval"] ?? this.interval;
+    this.aggregations = searchController["aggregations"] ?? this.aggregations;
+    this.missingLabel = searchController["missingLabel"] ?? this.missingLabel;
+    this.showMissing = searchController["showMissing"] ?? this.showMissing;
+    this.enableSynonyms =
+        searchController["enableSynonyms"] ?? this.enableSynonyms;
+    this.selectAllLabel =
+        searchController["selectAllLabel"] ?? this.selectAllLabel;
+    this.pagination = searchController["pagination"] ?? this.pagination;
+    this.queryString = searchController["queryString"] ?? this.queryString;
+    this.defaultQuery = searchController["defaultQuery"] ?? this.defaultQuery;
+    this.customQuery = searchController["customQuery"] ?? this.customQuery;
+    this.beforeValueChange =
+        searchController["beforeValueChange"] ?? this.beforeValueChange;
+    this.onValueChange =
+        searchController["onValueChange"] ?? this.onValueChange;
+    this.onResults = searchController["onResults"] ?? this.onResults;
+    this.onAggregationData =
+        searchController["onAggregationData"] ?? this.onAggregationData;
+    this.onError = searchController["onError"] ?? this.onError;
+    this.onRequestStatusChange =
+        searchController["onRequestStatusChange"] ?? this.onRequestStatusChange;
+    this.onQueryChange =
+        searchController["onQueryChange"] ?? this.onQueryChange;
+    this.enablePopularSuggestions =
+        searchController["enablePopularSuggestions"] ??
+            this.enablePopularSuggestions;
+    this.maxPopularSuggestions =
+        searchController["maxPopularSuggestions"] ?? this.maxPopularSuggestions;
+    this.showDistinctSuggestions =
+        searchController["showDistinctSuggestions"] ??
+            this.showDistinctSuggestions;
+    this.preserveResults =
+        searchController["preserveResults"] ?? this.preserveResults;
+    this.clearOnQueryChange =
+        searchController["clearOnQueryChange"] ?? this.clearOnQueryChange;
+    this.value = searchController["value"] ?? this.value;
+    this.distinctField =
+        searchController["distinctField"] ?? this.distinctField;
+    this.distinctFieldConfig =
+        searchController["distinctFieldConfig"] ?? this.distinctFieldConfig;
+    this.compoundClause =
+        searchController["compoundClause"] ?? this.compoundClause;
+    this.httpRequestTimeout =
+        searchController['httpRequestTimeout'] ?? this.httpRequestTimeout;
   }
 
   // Method to apply the changes based on set options

--- a/searchbase/lib/src/searchcontroller.dart
+++ b/searchbase/lib/src/searchcontroller.dart
@@ -384,6 +384,22 @@ class SearchController extends Base {
   /// Defaults to 30 seconds.
   Duration httpRequestTimeout;
 
+  /// Configure whether the DSL query is generated with the compound clause of [CompoundClauseType.must] or [CompoundClauseType.filter]. If nothing is passed the default is to use [CompoundClauseType.must].
+  /// Setting the compound clause to filter allows search engine to cache and allows for higher throughput in cases where scoring isn’t relevant (e.g. term, geo or range type of queries that act as filters on the data)
+  ///
+  /// This property only has an effect when the search engine is either elasticsearch or opensearch.
+  /// > Note: `compoundClause` is supported with v8.16.0 (server) as well as with serverless search.
+  ///
+  ///   ///
+  /// For example,
+  /// ```dart
+  /// SearchBox(
+  ///   ...
+  ///   compoundClause:  CompoundClauseType.filter
+  /// )
+  /// ```
+  CompoundClauseType? compoundClause;
+
   /* ---- callbacks to create the side effects while querying ----- */
 
   /// It is a callback function which accepts component's future **value** as a
@@ -502,6 +518,7 @@ class SearchController extends Base {
     this.value,
     this.clearOnQueryChange = false,
     this.httpRequestTimeout = const Duration(seconds: 30),
+    this.compoundClause,
   }) : super(index, url, credentials,
             appbaseConfig: appbaseConfig,
             transformRequest: transformRequest,
@@ -602,6 +619,7 @@ class SearchController extends Base {
       'index': this.index,
       'distinctField': distinctField,
       'distinctFieldConfig': distinctFieldConfig,
+      'compoundClause': compoundClause,
     };
     query.removeWhere((key, value) => key == null || value == null);
     return query;

--- a/searchbase/pubspec.yaml
+++ b/searchbase/pubspec.yaml
@@ -1,5 +1,5 @@
 name: searchbase
-version: 3.4.11-beta
+version: 3.4.12-beta
 description: SearchBase is a library to build the search UIs with Elasticsearch.
 homepage: https://github.com/appbaseio/flutter-searchbox
 environment:

--- a/searchbase/pubspec.yaml
+++ b/searchbase/pubspec.yaml
@@ -1,5 +1,5 @@
 name: searchbase
-version: 3.4.10-beta
+version: 3.4.11-beta
 description: SearchBase is a library to build the search UIs with Elasticsearch.
 homepage: https://github.com/appbaseio/flutter-searchbox
 environment:


### PR DESCRIPTION
`feat`

[📔 Notion](https://www.notion.so/reactivesearch/compoundClause-prop-support-b9a0eafedb294bbeb3d8f08b86ef162e)

The PR adds support for `compoundClause` property to flutter libs.

Also, adds support for overriding the widget config of a pre-registered widget.

```

flutter_searchbox: ^3.2.10-beta
searchbase: ^3.4.12-beta
flutter_searchbox_ui: ^3.2.11-beta
```